### PR TITLE
Nil Out Typed Values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ bigtable-*.tar
 /priv/googleapis
 
 /secret/service.json
+/lib/typed/test_schemas.ex
 .DS_Store

--- a/lib/typed/mutations.ex
+++ b/lib/typed/mutations.ex
@@ -27,18 +27,35 @@ defmodule Bigtable.Typed.Mutations do
     Enum.reduce(map, entry, fn {k, v}, accum ->
       column_qualifier = column_qualifier(parent_key, k)
 
-      if Map.get(type_spec, k) == nil do
-        accum
-      else
-        case is_map(v) do
-          true ->
-            child_spec = Map.get(type_spec, k)
-            apply_mutations(child_spec, v, accum, family_name, column_qualifier)
+      case Map.get(type_spec, k) do
+        nil ->
+          accum
 
-          false ->
-            accum
-            |> Bigtable.Mutations.set_cell(family_name, column_qualifier, v)
-        end
+        type when is_map(type) ->
+          nested_map(type, v, accum, family_name, column_qualifier)
+
+        _ ->
+          accum
+          |> Bigtable.Mutations.set_cell(family_name, column_qualifier, v)
+      end
+    end)
+  end
+
+  defp nested_map(type, value, accum, family_name, column_qualifier) do
+    if value == nil or value == "" do
+      niled_map = nil_values(type)
+      apply_mutations(type, niled_map, accum, family_name, column_qualifier)
+    else
+      apply_mutations(type, value, accum, family_name, column_qualifier)
+    end
+  end
+
+  defp nil_values(type_spec) do
+    Enum.reduce(type_spec, %{}, fn {k, v}, accum ->
+      if is_map(v) do
+        Map.put(accum, k, nil_values(v))
+      else
+        Map.put(accum, k, "")
       end
     end)
   end

--- a/test/typed/mutations_test.exs
+++ b/test/typed/mutations_test.exs
@@ -1,0 +1,121 @@
+defmodule TypedMutationsTest do
+  alias Bigtable.Typed.Mutations
+
+  use ExUnit.Case
+
+  describe "Typed.Mutations.create_mutations" do
+    setup do
+      [
+        row_key: "Test#1",
+        type_spec: %{
+          test_family: %{
+            test_column: :boolean,
+            test_nested: %{
+              nested_a: :boolean,
+              nested_b: :integer,
+              double_nested: %{
+                double_nested_a: :boolean,
+                double_nested_b: :integer
+              }
+            }
+          }
+        }
+      ]
+    end
+
+    test "should create mutations for a nested map", context do
+      map = %{
+        test_family: %{
+          test_column: false,
+          test_nested: %{
+            nested_a: true,
+            nested_b: 2,
+            double_nested: %{
+              double_nested_a: true,
+              double_nested_b: 2
+            }
+          }
+        }
+      }
+
+      expected = expected_entry(<<0, 0, 0, 1>>, <<0, 0, 0, 2>>)
+
+      result = Mutations.create_mutations(context.row_key, context.type_spec, map)
+
+      assert result == expected
+    end
+
+    test "should create nil properties for nil map value", context do
+      map = %{
+        test_family: %{
+          test_column: false,
+          test_nested: nil
+        }
+      }
+
+      expected = expected_entry("", "")
+
+      result = Mutations.create_mutations(context.row_key, context.type_spec, map)
+
+      assert result == expected
+    end
+  end
+
+  defp expected_entry(a_value, b_value) do
+    %Google.Bigtable.V2.MutateRowsRequest.Entry{
+      mutations: [
+        %Google.Bigtable.V2.Mutation{
+          mutation:
+            {:set_cell,
+             %Google.Bigtable.V2.Mutation.SetCell{
+               column_qualifier: "test_column",
+               family_name: "test_family",
+               timestamp_micros: -1,
+               value: <<0, 0, 0, 0>>
+             }}
+        },
+        %Google.Bigtable.V2.Mutation{
+          mutation:
+            {:set_cell,
+             %Google.Bigtable.V2.Mutation.SetCell{
+               column_qualifier: "test_nested.double_nested.double_nested_a",
+               family_name: "test_family",
+               timestamp_micros: -1,
+               value: a_value
+             }}
+        },
+        %Google.Bigtable.V2.Mutation{
+          mutation:
+            {:set_cell,
+             %Google.Bigtable.V2.Mutation.SetCell{
+               column_qualifier: "test_nested.double_nested.double_nested_b",
+               family_name: "test_family",
+               timestamp_micros: -1,
+               value: b_value
+             }}
+        },
+        %Google.Bigtable.V2.Mutation{
+          mutation:
+            {:set_cell,
+             %Google.Bigtable.V2.Mutation.SetCell{
+               column_qualifier: "test_nested.nested_a",
+               family_name: "test_family",
+               timestamp_micros: -1,
+               value: a_value
+             }}
+        },
+        %Google.Bigtable.V2.Mutation{
+          mutation:
+            {:set_cell,
+             %Google.Bigtable.V2.Mutation.SetCell{
+               column_qualifier: "test_nested.nested_b",
+               family_name: "test_family",
+               timestamp_micros: -1,
+               value: b_value
+             }}
+        }
+      ],
+      row_key: "Test#1"
+    }
+  end
+end


### PR DESCRIPTION
If a types pec contains a value that is itself a type spec, mutation generation for a nil value will create a map of empty strings matching the type spec to effectively clear out the value in Bigtable.