### PR TITLE
Value Stringification for BigQuery Adapter

### DIFF
--- a/lib/byte_string.ex
+++ b/lib/byte_string.ex
@@ -34,23 +34,25 @@ defmodule Bigtable.ByteString do
   @spec to_byte_string(nil) :: binary()
   def to_byte_string(v) when is_nil(v), do: ""
 
-  @spec to_byte_string(binary()) :: binary()
-  def to_byte_string(v) when is_binary(v), do: v
+  # @spec to_byte_string(binary()) :: binary()
+  # def to_byte_string(v) when is_binary(v), do: v
 
-  @spec to_byte_string(boolean()) :: binary()
-  def to_byte_string(v) when is_boolean(v) do
-    case v do
-      true -> to_byte_string(1)
-      false -> to_byte_string(0)
-    end
-  end
+  # @spec to_byte_string(boolean()) :: binary()
+  # def to_byte_string(v) when is_boolean(v) do
+  #   case v do
+  #     true -> to_byte_string(-1)
+  #     false -> to_byte_string(0)
+  #   end
+  # end
 
-  @spec to_byte_string(integer()) :: binary()
-  def to_byte_string(v) when is_integer(v), do: <<v::integer-signed-32>>
+  # @spec to_byte_string(integer()) :: binary()
+  # def to_byte_string(v) when is_integer(v), do: <<v::integer-signed-32>>
 
-  @spec to_byte_string(float()) :: binary()
-  def to_byte_string(v) when is_float(v), do: <<v::signed-little-float-64>>
+  # @spec to_byte_string(float()) :: binary()
+  # def to_byte_string(v) when is_float(v), do: <<v::signed-little-float-64>>
 
   @spec to_byte_string(list() | map()) :: binary()
   def to_byte_string(v) when is_list(v) or is_map(v), do: Poison.encode!(v)
+
+  def to_byte_string(v), do: to_string(v)
 end

--- a/lib/byte_string.ex
+++ b/lib/byte_string.ex
@@ -4,21 +4,22 @@ defmodule Bigtable.ByteString do
   def parse_value(_, ""), do: nil
   def parse_value(_, nil), do: nil
 
+  def parse_value(_, "true"), do: true
+  def parse_value(_, "false"), do: false
+
   @spec parse_value(:integer, binary()) :: integer()
   def parse_value(:integer, byte_string) do
-    <<v::integer-signed-32>> = byte_string
-    v
+    Integer.parse(byte_string)
   end
 
   @spec parse_value(:float, binary()) :: float()
   def parse_value(:float, byte_string) do
-    <<v::signed-little-float-64>> = byte_string
-    v
+    Float.parse(byte_string)
   end
 
   @spec parse_value(:string, binary()) :: binary()
   def parse_value(:string, byte_string) do
-    to_string(byte_string)
+    byte_string
   end
 
   @spec parse_value(:map, binary()) :: map()
@@ -33,23 +34,6 @@ defmodule Bigtable.ByteString do
 
   @spec to_byte_string(nil) :: binary()
   def to_byte_string(v) when is_nil(v), do: ""
-
-  # @spec to_byte_string(binary()) :: binary()
-  # def to_byte_string(v) when is_binary(v), do: v
-
-  # @spec to_byte_string(boolean()) :: binary()
-  # def to_byte_string(v) when is_boolean(v) do
-  #   case v do
-  #     true -> to_byte_string(-1)
-  #     false -> to_byte_string(0)
-  #   end
-  # end
-
-  # @spec to_byte_string(integer()) :: binary()
-  # def to_byte_string(v) when is_integer(v), do: <<v::integer-signed-32>>
-
-  # @spec to_byte_string(float()) :: binary()
-  # def to_byte_string(v) when is_float(v), do: <<v::signed-little-float-64>>
 
   @spec to_byte_string(list() | map()) :: binary()
   def to_byte_string(v) when is_list(v) or is_map(v), do: Poison.encode!(v)

--- a/test/typed/mutations_test.exs
+++ b/test/typed/mutations_test.exs
@@ -38,7 +38,7 @@ defmodule TypedMutationsTest do
         }
       }
 
-      expected = expected_entry(<<0, 0, 0, 1>>, <<0, 0, 0, 2>>)
+      expected = expected_entry("true", "2")
 
       result = Mutations.create_mutations(context.row_key, context.type_spec, map)
 
@@ -71,7 +71,7 @@ defmodule TypedMutationsTest do
                column_qualifier: "test_column",
                family_name: "test_family",
                timestamp_micros: -1,
-               value: <<0, 0, 0, 0>>
+               value: "false"
              }}
         },
         %Google.Bigtable.V2.Mutation{


### PR DESCRIPTION
For now values will be converted to literal strings instead of byte arrays. There was an issue with BigQuery's Bigtable adapter being able to correctly parse boolean values that were converted to byte arrays. Will need to investigate the return value of HBase converting booleans to byte arrays.