### PR TITLE
Nil value handling with typed mutation generation

### DIFF
--- a/lib/typed/mutations.ex
+++ b/lib/typed/mutations.ex
@@ -36,9 +36,19 @@ defmodule Bigtable.Typed.Mutations do
 
         _ ->
           accum
-          |> Bigtable.Mutations.set_cell(family_name, column_qualifier, v)
+          |> add_cell_mutation(family_name, column_qualifier, v)
       end
     end)
+  end
+
+  defp add_cell_mutation(accum, family_name, column_qualifier, nil) do
+    accum
+    |> Bigtable.Mutations.delete_from_column(family_name, column_qualifier)
+  end
+
+  defp add_cell_mutation(accum, family_name, column_qualifier, value) do
+    accum
+    |> Bigtable.Mutations.set_cell(family_name, column_qualifier, value)
   end
 
   defp nested_map(type, value, accum, family_name, column_qualifier) do
@@ -55,7 +65,7 @@ defmodule Bigtable.Typed.Mutations do
       if is_map(v) do
         Map.put(accum, k, nil_values(v))
       else
-        Map.put(accum, k, "")
+        Map.put(accum, k, nil)
       end
     end)
   end

--- a/test/typed/mutations_test.exs
+++ b/test/typed/mutations_test.exs
@@ -53,7 +53,69 @@ defmodule TypedMutationsTest do
         }
       }
 
-      expected = expected_entry("", "")
+      expected = %Google.Bigtable.V2.MutateRowsRequest.Entry{
+        row_key: "Test#1",
+        mutations: [
+          %Google.Bigtable.V2.Mutation{
+            mutation:
+              {:set_cell,
+               %Google.Bigtable.V2.Mutation.SetCell{
+                 column_qualifier: "test_column",
+                 family_name: "test_family",
+                 timestamp_micros: -1,
+                 value: "false"
+               }}
+          },
+          %Google.Bigtable.V2.Mutation{
+            mutation:
+              {:delete_from_column,
+               %Google.Bigtable.V2.Mutation.DeleteFromColumn{
+                 column_qualifier: "test_nested.double_nested.double_nested_a",
+                 family_name: "test_family",
+                 time_range: %Google.Bigtable.V2.TimestampRange{
+                   end_timestamp_micros: 0,
+                   start_timestamp_micros: 0
+                 }
+               }}
+          },
+          %Google.Bigtable.V2.Mutation{
+            mutation:
+              {:delete_from_column,
+               %Google.Bigtable.V2.Mutation.DeleteFromColumn{
+                 column_qualifier: "test_nested.double_nested.double_nested_b",
+                 family_name: "test_family",
+                 time_range: %Google.Bigtable.V2.TimestampRange{
+                   end_timestamp_micros: 0,
+                   start_timestamp_micros: 0
+                 }
+               }}
+          },
+          %Google.Bigtable.V2.Mutation{
+            mutation:
+              {:delete_from_column,
+               %Google.Bigtable.V2.Mutation.DeleteFromColumn{
+                 column_qualifier: "test_nested.nested_a",
+                 family_name: "test_family",
+                 time_range: %Google.Bigtable.V2.TimestampRange{
+                   end_timestamp_micros: 0,
+                   start_timestamp_micros: 0
+                 }
+               }}
+          },
+          %Google.Bigtable.V2.Mutation{
+            mutation:
+              {:delete_from_column,
+               %Google.Bigtable.V2.Mutation.DeleteFromColumn{
+                 column_qualifier: "test_nested.nested_b",
+                 family_name: "test_family",
+                 time_range: %Google.Bigtable.V2.TimestampRange{
+                   end_timestamp_micros: 0,
+                   start_timestamp_micros: 0
+                 }
+               }}
+          }
+        ]
+      }
 
       result = Mutations.create_mutations(context.row_key, context.type_spec, map)
 


### PR DESCRIPTION
Switches nil values to delete columns instead of filling with empty string. Change made to integrate better with BigQuery adapter in short term