### PR TITLE
Add and fix some type specs

### DIFF
--- a/lib/data/chunk_reader.ex
+++ b/lib/data/chunk_reader.ex
@@ -9,6 +9,15 @@ defmodule Bigtable.ChunkReader do
     @moduledoc """
     A finished cell produced by `Bigtable.ChunkReader`.
     """
+    @type t :: %__MODULE__{
+            label: binary(),
+            row_key: binary(),
+            family_name: Google.Protobuf.StringValue.t(),
+            qualifier: Google.Protobuf.BytesValue.t(),
+            timestamp: non_neg_integer,
+            value: binary()
+          }
+
     defstruct [
       :label,
       :row_key,

--- a/lib/data/row_set.ex
+++ b/lib/data/row_set.ex
@@ -107,8 +107,8 @@ defmodule Bigtable.RowSet do
           V2.ReadRowsRequest.t(),
           [{binary(), binary(), binary()}]
           | [{binary(), binary()}]
-          | [{binary(), binary(), binary()}]
           | {binary(), binary(), binary()}
+          | {binary(), binary()}
         ) :: V2.ReadRowsRequest.t()
   def row_ranges(%V2.ReadRowsRequest{} = request, ranges) do
     ranges = List.flatten([ranges])

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -53,7 +53,7 @@ defmodule Bigtable.Utils do
     Application.get_env(:bigtable, :instance)
   end
 
-  @spec process_stream(Enumerable.t({atom(), resp})) :: [{atom(), resp}] when resp: var
+  @spec process_stream(Enumerable.t()) :: [{atom(), any}]
   defp process_stream(stream) do
     stream
     |> Stream.take_while(&remaining_resp?/1)


### PR DESCRIPTION
While testing the library I found that there are some missing type specs and others are wrong.

There are still two errors that I don't know how to solve:

- `unknown Google.Bigtable.V2.MutateRowResponse.t/0` doesn't have type `t`, but are no struct, is it not implemented yet or it's an empty struct the response?
- `unknown Google.Protobuf.FieldMask.t/0` I couldn't find this struct on google_protos nor protobuf repositories